### PR TITLE
Add an initial check on Lenses starting to make sure we only run on Linux systems

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 
+onlyLinux()
+{
+    UNAME=$(which uname)
+    if [ "xx$UNAME" == "xx" ]
+    then
+	echo "Unable to identify system. Uname is required"
+	exit 1
+    fi
+
+    systemType="$($UNAME -s)"
+    case "$systemType" in
+	Linux*) return ;;
+    esac
+
+    echo "You are running on $systemType system. Lenses currently support only Linux."
+    echo "Please follow the installation instructions on docs.lenses.io"
+    exit 1
+}
+
+onlyLinux
+
 echo "Initializing environment —docker setup script."
 
 umask 0077


### PR DESCRIPTION
This is quite simple test using uname. The list of possible answers for uname was
found from : https://en.wikipedia.org/wiki/Uname

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/lenses-docker/14)
<!-- Reviewable:end -->
